### PR TITLE
Remove *IP and fix namespace Proxy->HTTPProxy

### DIFF
--- a/cmd/routedns/config.go
+++ b/cmd/routedns/config.go
@@ -33,7 +33,7 @@ type listener struct {
 
 // DoH-specific resolver options
 type dohListener struct {
-	ProxyAddr  string   `toml:"trusted-proxy"`
+	HTTPProxyAddr string `toml:"trusted-proxy"`
 }
 
 type resolver struct {

--- a/cmd/routedns/example-config/doh-behind-proxy.toml
+++ b/cmd/routedns/example-config/doh-behind-proxy.toml
@@ -1,12 +1,12 @@
-# Server-side of a simple DNS-over-HTTPS proxy that is behind a reverse proxy.
-# The X-Forwarded-For header from the reverse proxy (trusted-proxy: 192.168.1.2)
+# Server-side of a DNS-over-HTTPS proxy that is behind an HTTP reverse proxy.
+# The X-Forwarded-For header provided by the trusted-proxy (on 192.168.1.2)
 # will be used to determine the client address.
 
 [resolvers.cloudflare-dot]
 address = "1.1.1.1:853"
 protocol = "dot"
 
-[listeners.local-doh-quic]
+[listeners.local-doh-behind-proxy]
 address = ":443"
 protocol = "doh"
 resolver = "cloudflare-dot"

--- a/cmd/routedns/main.go
+++ b/cmd/routedns/main.go
@@ -244,15 +244,15 @@ func start(opt options, args []string) error {
 			if err != nil {
 				return err
 			}
-			proxyAddr := net.ParseIP(l.DoH.ProxyAddr)
-			if l.DoH.ProxyAddr != "" && proxyAddr == nil {
-				return fmt.Errorf("listener '%s' proxy-address '%s' is not an IPv4 or IPv6 address", id, l.DoH.ProxyAddr)
+			httpProxyAddr := net.ParseIP(l.DoH.HTTPProxyAddr)
+			if l.DoH.HTTPProxyAddr != "" && httpProxyAddr == nil {
+				return fmt.Errorf("listener '%s' proxy-address '%s' is not an IPv4 or IPv6 address", id, l.DoH.HTTPProxyAddr)
 			}
 			opt := rdns.DoHListenerOptions{
 				TLSConfig:     tlsConfig,
 				ListenOptions: opt,
 				Transport:     l.Transport,
-				ProxyAddr:     &proxyAddr,
+				HTTPProxyAddr: httpProxyAddr,
 			}
 			ln, err := rdns.NewDoHListener(id, l.Address, opt, resolver)
 			if err != nil {

--- a/dohlistener.go
+++ b/dohlistener.go
@@ -45,7 +45,7 @@ type DoHListenerOptions struct {
 	TLSConfig *tls.Config
 
 	// IP(v4/v6) of a known reverse proxy in front of this server.
-	ProxyAddr *net.IP
+	HTTPProxyAddr net.IP
 }
 
 // NewDoHListener returns an instance of a DNS-over-HTTPS listener.
@@ -174,13 +174,13 @@ func (s *DoHListener) extractClientAddress(r *http.Request) net.IP {
 	xForwardedFor := r.Header.Get("X-Forwarded-For")
 
 	// Simple case: No proxy (or empty/long X-Forwarded-For).
-	if s.opt.ProxyAddr == nil || xForwardedFor == "" || len(xForwardedFor) >= 1024 {
+	if s.opt.HTTPProxyAddr == nil || xForwardedFor == "" || len(xForwardedFor) >= 1024 {
 		return clientIP
 	}
 
 	// If our client is a reverse proxy then use the last entry in X-Forwarded-For.
 	chain := strings.Split(xForwardedFor, ", ")
-	if clientIP != nil && s.opt.ProxyAddr.Equal(clientIP) {
+	if clientIP != nil && s.opt.HTTPProxyAddr.Equal(clientIP) {
 		if ip := net.ParseIP(chain[len(chain)-1]); ip != nil {
 			// Ignore XFF whe the client is local to the proxy.
 			if !ip.IsLoopback() {

--- a/dohlistener_test.go
+++ b/dohlistener_test.go
@@ -55,8 +55,8 @@ func TestDoHListenerSimple(t *testing.T) {
 	// The upstream resolver should have seen the query
 	require.Equal(t, 2, upstream.HitCount())
 
-	// The listener should not use X-Forwarded-For if ProxyAddr is not set.
-	require.Nil(t, s.opt.ProxyAddr)
+	// The listener should not use X-Forwarded-For if HTTPProxyAddr is not set.
+	require.Nil(t, s.opt.HTTPProxyAddr)
 	r, _ := http.NewRequest("GET", "https://www.example.com", nil)
 	r.RemoteAddr = "10.0.0.2:1234"
 	r.Header.Add("X-Forwarded-For", "10.0.1.3")
@@ -145,11 +145,11 @@ func TestClientBehindProxy(t *testing.T) {
 
 	expectedProxyAddr := "10.0.0.2"
 	proxyAddr := net.ParseIP(expectedProxyAddr)
-	s, err := NewDoHListener("test-doh", addr, DoHListenerOptions{TLSConfig: tlsServerConfig, ProxyAddr: &proxyAddr}, upstream)
+	s, err := NewDoHListener("test-doh", addr, DoHListenerOptions{TLSConfig: tlsServerConfig, HTTPProxyAddr: proxyAddr}, upstream)
 	require.NoError(t, err)
 
 	// Verify that the ProxyAddr has been set.
-	require.Equal(t, expectedProxyAddr, s.opt.ProxyAddr.String())
+	require.Equal(t, expectedProxyAddr, s.opt.HTTPProxyAddr.String())
 
 	// There is no proxy.
 	r, _ := http.NewRequest("GET", "https://www.example.com", nil)
@@ -227,11 +227,11 @@ func TestIPv6Proxy(t *testing.T) {
 
 	expectedProxyAddr := "2001:4860:4860::8"
 	proxyAddr := net.ParseIP(expectedProxyAddr)
-	s, err := NewDoHListener("test-doh", addr, DoHListenerOptions{TLSConfig: tlsServerConfig, ProxyAddr: &proxyAddr}, upstream)
+	s, err := NewDoHListener("test-doh", addr, DoHListenerOptions{TLSConfig: tlsServerConfig, HTTPProxyAddr: proxyAddr}, upstream)
 	require.NoError(t, err)
 
 	// Verify that the ProxyAddr has been set.
-	require.Equal(t, expectedProxyAddr, s.opt.ProxyAddr.String())
+	require.Equal(t, expectedProxyAddr, s.opt.HTTPProxyAddr.String())
 
 	// There is no proxy.
 	r, _ := http.NewRequest("GET", "https://www.example.com", nil)


### PR DESCRIPTION
HTTPProxy is still ambigious until you consider that it's being used in the context of
a listener rather than a client.  Since it's a listener the HTTPProxy is clearly incoming
rather than outgoing.